### PR TITLE
Fit Flamegraph Height Into Given Area

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
             const colorScale = d3.scaleOrdinal(d3.schemeCategory10);
 
             const partition = d3.partition()
-                .size([width, height])
+                .size([height, width])
                 .padding(1)
                 .round(true);
 


### PR DESCRIPTION
When height doesn't fit the div, the canvas is cropped.
This updates fits the canvas into the area.
I suppose the original intention was similar.